### PR TITLE
Fix compatibility with Symfony 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,14 +4,14 @@
     "type": "library",
     "license": "MIT",
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.4",
         "dazet/type-utils": "^0.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.1",
-        "symfony/console": "^5.0",
-        "symfony/http-kernel": "^5.0",
-        "symfony/error-handler": "^5.0"
+        "phpunit/phpunit": "^11.0",
+        "symfony/console": "^8.1",
+        "symfony/http-kernel": "^8.1",
+        "symfony/error-handler": "^8.1"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
     bootstrap="tests/bootstrap.php"
 >
     <testsuites>

--- a/src/SafeRequest.php
+++ b/src/SafeRequest.php
@@ -77,6 +77,21 @@ final class SafeRequest
      */
     public function value(string $key, $default)
     {
-        return $this->request->get($key, $default);
+        $attributes = $this->request->attributes;
+        if ($attributes->has($key)) {
+            return $attributes->all()[$key];
+        }
+
+        $query = $this->request->query;
+        if ($query->has($key)) {
+            return $query->all()[$key];
+        }
+
+        $post = $this->request->request;
+        if ($post->has($key)) {
+            return $post->all()[$key];
+        }
+
+        return $default;
     }
 }

--- a/tests/SafeBoolTest.php
+++ b/tests/SafeBoolTest.php
@@ -4,17 +4,18 @@ namespace tests\GW\Safe;
 
 use GW\Safe\SafeAssocArray;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class SafeBoolTest extends TestCase
 {
-    /** @dataProvider possibleBooleanValues */
+    #[DataProvider('possibleBooleanValues')]
     function test_casting_possible_bool_values($value, bool $expected)
     {
         self::assertEquals($expected, SafeAssocArray::from(['bool' => $value])->bool('bool'));
     }
 
-    /** @dataProvider impossibleBooleanValues */
+    #[DataProvider('impossibleBooleanValues')]
     function test_throwing_InvalidArgumentException_on_value_that_cannot_be_bool($notBool)
     {
         $this->expectException(InvalidArgumentException::class);
@@ -27,7 +28,7 @@ class SafeBoolTest extends TestCase
         SafeAssocArray::from(['value' => null])->bool('value');
     }
 
-    /** @dataProvider impossibleBooleanValues */
+    #[DataProvider('impossibleBooleanValues')]
     function test_returning_default_when_value_is_not_bool($notBool)
     {
         $safe = SafeAssocArray::from(['value' => $notBool]);
@@ -36,7 +37,7 @@ class SafeBoolTest extends TestCase
         self::assertFalse($safe->boolOrDefault('value', false));
     }
 
-    public function possibleBooleanValues(): array
+    public static function possibleBooleanValues(): array
     {
         return [
             [true, true],
@@ -48,7 +49,7 @@ class SafeBoolTest extends TestCase
         ];
     }
 
-    public function impossibleBooleanValues(): array
+    public static function impossibleBooleanValues(): array
     {
         return [
             ['YES'],

--- a/tests/SafeFloatTest.php
+++ b/tests/SafeFloatTest.php
@@ -4,6 +4,7 @@ namespace tests\GW\Safe;
 
 use GW\Safe\SafeAssocArray;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use function random_int;
@@ -11,7 +12,7 @@ use const M_PI;
 
 class SafeFloatTest extends TestCase
 {
-    /** @dataProvider possibleFloatValues */
+    #[DataProvider('possibleFloatValues')]
     function test_casting_possible_float_values($value, float $expected)
     {
         self::assertEquals($expected, SafeAssocArray::from(['float' => $value])->float('float'));
@@ -20,21 +21,21 @@ class SafeFloatTest extends TestCase
         self::assertEquals($expected, SafeAssocArray::from(['float' => $value])->floatOrDefault('float', M_PI));
     }
 
-    /** @dataProvider impossibleFloatValues */
+    #[DataProvider('impossibleFloatValues')]
     function test_throwing_InvalidArgumentException_on_value_that_cannot_be_float($notFloat)
     {
         $this->expectException(InvalidArgumentException::class);
         SafeAssocArray::from(['value' => $notFloat])->float('value');
     }
 
-    /** @dataProvider impossibleFloatValues */
+    #[DataProvider('impossibleFloatValues')]
     function test_throwing_InvalidArgumentException_on_value_that_cannot_be_float_nullable($notFloat)
     {
         $this->expectException(InvalidArgumentException::class);
         SafeAssocArray::from(['value' => $notFloat])->floatNullable('value');
     }
 
-    /** @dataProvider impossibleFloatValues */
+    #[DataProvider('impossibleFloatValues')]
     function test_floatOrNull_returns_null_on_value_that_cannot_be_number($notFloat)
     {
         self::assertNull(SafeAssocArray::from(['value' => $notFloat])->floatOrNull('value'));
@@ -46,7 +47,7 @@ class SafeFloatTest extends TestCase
         SafeAssocArray::from(['value' => null])->float('value');
     }
 
-    /** @dataProvider impossibleFloatValues */
+    #[DataProvider('impossibleFloatValues')]
     function test_returning_default_when_value_is_not_numeric($notFloat)
     {
         $safe = SafeAssocArray::from(['value' => $notFloat]);
@@ -113,7 +114,7 @@ class SafeFloatTest extends TestCase
         self::assertEquals([123.99, 42.42, 456.99, 42.42], $safe->floatsForced('floats', 42.42));
     }
 
-    public function possibleFloatValues(): array
+    public static function possibleFloatValues(): array
     {
         return [
             [123, 123.0],
@@ -124,7 +125,7 @@ class SafeFloatTest extends TestCase
         ];
     }
 
-    public function impossibleFloatValues(): array
+    public static function impossibleFloatValues(): array
     {
         return [
             [['array']],

--- a/tests/SafeIntTest.php
+++ b/tests/SafeIntTest.php
@@ -4,14 +4,14 @@ namespace tests\GW\Safe;
 
 use GW\Safe\SafeAssocArray;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use function random_int;
-use function uniqid;
 
 class SafeIntTest extends TestCase
 {
-    /** @dataProvider possibleIntegerValues */
+    #[DataProvider('possibleIntegerValues')]
     function test_casting_possible_int_values($value, int $expected)
     {
         self::assertEquals($expected, SafeAssocArray::from(['int' => $value])->int('int'));
@@ -20,21 +20,21 @@ class SafeIntTest extends TestCase
         self::assertEquals($expected, SafeAssocArray::from(['int' => $value])->intOrDefault('int', random_int(0, 99)));
     }
 
-    /** @dataProvider impossibleIntegerValues */
+    #[DataProvider('impossibleIntegerValues')]
     function test_throwing_InvalidArgumentException_on_value_that_cannot_be_int($notInt)
     {
         $this->expectException(InvalidArgumentException::class);
         SafeAssocArray::from(['value' => $notInt])->int('value');
     }
 
-    /** @dataProvider impossibleIntegerValues */
+    #[DataProvider('impossibleIntegerValues')]
     function test_throwing_InvalidArgumentException_on_value_that_cannot_be_int_nullable($notInt)
     {
         $this->expectException(InvalidArgumentException::class);
         SafeAssocArray::from(['value' => $notInt])->intNullable('value');
     }
 
-    /** @dataProvider impossibleIntegerValues */
+    #[DataProvider('impossibleIntegerValues')]
     function test_intOrNull_returns_null_on_value_that_cannot_be_int($notInt)
     {
         self::assertNull(SafeAssocArray::from(['value' => $notInt])->intOrNull('value'));
@@ -46,7 +46,7 @@ class SafeIntTest extends TestCase
         SafeAssocArray::from(['value' => null])->int('value');
     }
 
-    /** @dataProvider impossibleIntegerValues */
+    #[DataProvider('impossibleIntegerValues')]
     function test_returning_default_when_value_is_not_numeric($notInt)
     {
         $safe = SafeAssocArray::from(['value' => $notInt]);
@@ -113,7 +113,7 @@ class SafeIntTest extends TestCase
         self::assertEquals([123, 42, 456, 42], $safe->intsForced('ints', 42));
     }
 
-    public function possibleIntegerValues(): array
+    public static function possibleIntegerValues(): array
     {
         return [
             [123, 123],
@@ -124,7 +124,7 @@ class SafeIntTest extends TestCase
         ];
     }
 
-    public function impossibleIntegerValues(): array
+    public static function impossibleIntegerValues(): array
     {
         return [
             [['array']],

--- a/tests/SafeRequestTest.php
+++ b/tests/SafeRequestTest.php
@@ -4,11 +4,94 @@ namespace tests\GW\Safe;
 
 use GW\Safe\SafeAssocArray;
 use GW\Safe\SafeRequest;
+use LogicException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 
 class SafeRequestTest extends TestCase
 {
+    public function test_mustBeFrom_throws_on_null()
+    {
+        $this->expectException(LogicException::class);
+        SafeRequest::mustBeFrom(null);
+    }
+
+    public function test_mustBeFrom_returns_instance()
+    {
+        $request = new Request();
+        self::assertInstanceOf(SafeRequest::class, SafeRequest::mustBeFrom($request));
+    }
+
+    public function test_request_returns_original_request()
+    {
+        $request = new Request();
+        self::assertSame($request, SafeRequest::from($request)->request());
+    }
+
+    public function test_ip()
+    {
+        $request = Request::create('/', 'GET', [], [], [], ['REMOTE_ADDR' => '1.2.3.4']);
+        self::assertSame('1.2.3.4', SafeRequest::from($request)->ip());
+    }
+
+    public function test_ip_throws_when_not_set()
+    {
+        $request = new Request();
+        $this->expectException(LogicException::class);
+        SafeRequest::from($request)->ip();
+    }
+
+    public function test_ipElse_returns_ip_when_set()
+    {
+        $request = Request::create('/', 'GET', [], [], [], ['REMOTE_ADDR' => '1.2.3.4']);
+        self::assertSame('1.2.3.4', SafeRequest::from($request)->ipElse('fallback'));
+    }
+
+    public function test_ipElse_returns_default_when_not_set()
+    {
+        $request = new Request();
+        self::assertSame('fallback', SafeRequest::from($request)->ipElse('fallback'));
+    }
+
+    public function test_ipElse_default_is_unknown()
+    {
+        $request = new Request();
+        self::assertSame('unknown', SafeRequest::from($request)->ipElse());
+    }
+
+    public function test_session()
+    {
+        $request = new Request();
+        $session = new Session(new MockArraySessionStorage());
+        $request->setSession($session);
+
+        self::assertSame($session, SafeRequest::from($request)->session());
+    }
+
+    public function test_value()
+    {
+        $request = new Request(
+            ['query_param' => 'from_query', 'shared' => 'from_query'],
+            ['post_param' => 'from_post', 'shared' => 'from_post'],
+            ['attr_param' => 'from_attr', 'shared' => 'from_attr'],
+        );
+        $safeRequest = SafeRequest::from($request);
+
+        self::assertEquals('from_query', $safeRequest->value('query_param', null));
+        self::assertEquals('from_post', $safeRequest->value('post_param', null));
+        self::assertEquals('from_attr', $safeRequest->value('attr_param', null));
+        self::assertEquals('from_attr', $safeRequest->value('shared', null), 'attributes take priority');
+        self::assertEquals('default', $safeRequest->value('missing', 'default'));
+    }
+
+    public function test_value_returns_null_when_key_exists_with_null_value()
+    {
+        $request = new Request(['param' => null]);
+        self::assertNull(SafeRequest::from($request)->value('param', 'default'));
+    }
+
     public function test_from()
     {
         $request = new Request(

--- a/tests/SafeStringTest.php
+++ b/tests/SafeStringTest.php
@@ -4,6 +4,7 @@ namespace tests\GW\Safe;
 
 use GW\Safe\SafeAssocArray;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use function tmpfile;
@@ -11,7 +12,7 @@ use function uniqid;
 
 class SafeStringTest extends TestCase
 {
-    /** @dataProvider possibleStringValues */
+    #[DataProvider('possibleStringValues')]
     function test_casts_possible_string_values($value, string $expected)
     {
         self::assertEquals($expected, SafeAssocArray::from(['string' => $value])->string('string'));
@@ -20,21 +21,21 @@ class SafeStringTest extends TestCase
         self::assertEquals($expected, SafeAssocArray::from(['string' => $value])->stringOrDefault('string', uniqid()));
     }
 
-    /** @dataProvider impossibleStringValues */
+    #[DataProvider('impossibleStringValues')]
     function test_throwing_InvalidArgumentException_on_value_that_cannot_be_string($notString)
     {
         $this->expectException(InvalidArgumentException::class);
         SafeAssocArray::from(['value' => $notString])->string('value');
     }
 
-    /** @dataProvider impossibleStringValues */
+    #[DataProvider('impossibleStringValues')]
     function test_throwing_InvalidArgumentException_on_value_that_cannot_be_stringNullable($notString)
     {
         $this->expectException(InvalidArgumentException::class);
         SafeAssocArray::from(['value' => $notString])->stringNullable('value');
     }
 
-    /** @dataProvider impossibleStringValues */
+    #[DataProvider('impossibleStringValues')]
     function test_stringOrNull_returns_null_on_value_that_cannot_be_string($notString)
     {
         self::assertNull(SafeAssocArray::from(['value' => $notString])->stringOrNull('value'));
@@ -46,7 +47,7 @@ class SafeStringTest extends TestCase
         SafeAssocArray::from(['value' => null])->string('value');
     }
 
-    /** @dataProvider impossibleStringValues */
+    #[DataProvider('impossibleStringValues')]
     function test_returning_default_when_value_is_not_string_like($notString)
     {
         $safe = SafeAssocArray::from(['value' => $notString]);
@@ -121,7 +122,7 @@ class SafeStringTest extends TestCase
         );
     }
 
-    public function possibleStringValues(): array
+    public static function possibleStringValues(): array
     {
         return [
             ['string', 'string'],
@@ -133,7 +134,7 @@ class SafeStringTest extends TestCase
         ];
     }
 
-    public function impossibleStringValues(): array
+    public static function impossibleStringValues(): array
     {
         return [
             [['array']],


### PR DESCRIPTION
- Bump symfony/* dev deps to ^8.1, phpunit to ^11.0, php to ^8.4
- Replace removed Request::get() with explicit attributes→query→post lookup
- Fix data providers to be static (PHPUnit 11 requirement)
- Replace @dataProvider docblock annotations with #[DataProvider] attributes
- Add full test coverage for SafeRequest methods